### PR TITLE
Corrects errors in y-coordinate values caused in PlayerAuthInputPacket calculations

### DIFF
--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -201,7 +201,7 @@ class InGamePacketHandler extends PacketHandler{
 		}
 
 		$hasMoved = $this->lastPlayerAuthInputPosition === null || !$this->lastPlayerAuthInputPosition->equals($rawPos);
-		$newPos = $rawPos->round(4)->subtract(0, 1.62, 0);
+		$newPos = $rawPos->subtract(0, 1.62, 0)->round(4);
 
 		if($this->forceMoveSync && $hasMoved){
 			$curPos = $this->player->getLocation();


### PR DESCRIPTION
## Introduction
PlayerAuthInputPacket coordinate calculations were rounded and then subtracted, resulting in errors at certain coordinates.
Therefore, subtracting and then rounding the values corrects this problem.

## Tests
Move to the coordinates where the error occurs (e.g. y=7, 8, 31, 32, etc.) and output the coordinates with `var_dump()`.